### PR TITLE
fixing a deprecated dependency & change project name in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tailwindmaterialui",
+  "name": "Geekout",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwindmaterialui",
+      "name": "Geekout",
       "version": "0.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.3",
@@ -13,6 +13,7 @@
         "@hapi/tlds": "^1.0.2",
         "@hookform/devtools": "^4.3.1",
         "@hookform/resolvers": "^3.3.4",
+        "@leecheuk/react-google-login": "^5.4.1",
         "@mui/icons-material": "^5.15.11",
         "@mui/joy": "^5.0.0-beta.29",
         "@mui/material": "^5.15.19",
@@ -23,7 +24,6 @@
         "joi": "^17.12.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-google-login": "^5.2.2",
         "react-hook-form": "^7.50.1",
         "react-icons": "^5.0.1",
         "react-image-zoom": "^1.3.1",
@@ -1271,6 +1271,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@leecheuk/react-google-login": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@leecheuk/react-google-login/-/react-google-login-5.4.1.tgz",
+      "integrity": "sha512-2DtfOW9Ckt3M3RDy+3KAizqT9ts6im0Af0s+PBt9p6aKZEj7xL6P8v1nMcobGrffQnD+JQIyrhKozvuAYsP+Cg==",
+      "dependencies": {
+        "@types/react": "*",
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/@mui/base": {
@@ -4319,20 +4332,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-google-login": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/react-google-login/-/react-google-login-5.2.2.tgz",
-      "integrity": "sha512-JUngfvaSMcOuV0lFff7+SzJ2qviuNMQdqlsDJkUM145xkGPVIfqWXq9Ui+2Dr6jdJWH5KYdynz9+4CzKjI5u6g==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@types/react": "*",
-        "prop-types": "^15.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tailwindmaterialui",
+  "name": "Geekout",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -15,6 +15,7 @@
     "@hapi/tlds": "^1.0.2",
     "@hookform/devtools": "^4.3.1",
     "@hookform/resolvers": "^3.3.4",
+    "@leecheuk/react-google-login": "^5.4.1",
     "@mui/icons-material": "^5.15.11",
     "@mui/joy": "^5.0.0-beta.29",
     "@mui/material": "^5.15.19",
@@ -25,7 +26,6 @@
     "joi": "^17.12.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-google-login": "^5.2.2",
     "react-hook-form": "^7.50.1",
     "react-icons": "^5.0.1",
     "react-image-zoom": "^1.3.1",

--- a/src/components/auth/login/loginComponents/GoogleLoginButton.tsx
+++ b/src/components/auth/login/loginComponents/GoogleLoginButton.tsx
@@ -1,4 +1,4 @@
-import { GoogleLogin } from "react-google-login"
+import { GoogleLogin } from "@leecheuk/react-google-login"
 import { FcGoogle } from "react-icons/fc";
 import useAxios from "../../../../customHooks/useAxios";
 import { useContext, useState } from "react";


### PR DESCRIPTION
- Replace react-google-login library with a forked fixed deprecation library.
- Change project name inside package.json to "Geekout".